### PR TITLE
Change autodrain threshold to 47h

### DIFF
--- a/ansible-roles/group_vars/all.yml
+++ b/ansible-roles/group_vars/all.yml
@@ -4,7 +4,7 @@ galaxy_gid: 999
 condor_local_config: /etc/condor/condor_config.local
 
 central_manager: false
-vg_build: 24
+vg_build: 25
 vg_cluster: "vgcn"
 cloud: "default"
 

--- a/ansible-roles/group_vars/cloud-NEMO.yml
+++ b/ansible-roles/group_vars/cloud-NEMO.yml
@@ -1,6 +1,6 @@
 condor_enable_autoshutdown: true
-condor_drain_delay: 86400
-condor_drain_grace: 84600
+condor_drain_delay: 169200
+condor_drain_grace: 1800
 condor_master: 10.19.0.16
 condor_allowed_write: 10.19.0.0/16, 10.5.68.0/24, 132.230.68.0/24, *.bi.uni-freiburg.de
 condor_allowed_admin: 10.19.0.0/16


### PR DESCRIPTION
Having VG/NEMO CN nodes autodrain after only 24h has unwanted
consequences in that ROCED by default counts unclaimed slots of
draining hosts as available and thus often fails to start new
instances when they are required. (There is a config option named
'ignore_draining_machines' which does the opposite of what you'd
expect it to: when set to /false/ ROCED does /not/ count slots
of draining hosts as available; but with this option activted,
it also fails to count claimed slots on draining instances as
running and thus will often start unneeded instances, which is
not exactly desireable either...)

Thus this commit just sets the autodrain threshold to 47h and
the grace period to 30m (VMs on NEMO can run up to 48h walltime)
while keeping the default value of 'ignore_draining_machines'
unchanged which could cause delayed scheduling of jobs in some
cases but will hopefully alleviates the problem to the point
where it is no longer really one.

(Sry for the lengthy commit message, but I lack the time to make
it shorter...)

Bumped image version to 25.