### PR TITLE
Storage path for /data/dnb01 changed

### DIFF
--- a/ansible-roles/autofs/tasks/main.yml
+++ b/ansible-roles/autofs/tasks/main.yml
@@ -35,7 +35,7 @@
         5       -rw,hard,intr,nosuid,quota      sn03.bi.uni-freiburg.de:/export/galaxy1/data/&
         6       -rw,hard,intr,nosuid,quota      sn03.bi.uni-freiburg.de:/export/galaxy1/data/&
         7       -rw,hard,intr,nosuid,quota      sn03.bi.uni-freiburg.de:/export/galaxy1/data/&
-        dnb01   -rw,hard,intr,nosuid,quota      ufr.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/nfs/denbi
+        dnb01   -rw,hard,intr,nosuid,quota      ufr.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
         db      -rw,hard,intr,nosuid,quota      sn02.bi.uni-freiburg.de:/export/fdata1/galaxy/net/data/&
 
   - name: autofs map scratch


### PR DESCRIPTION
Note the trailing "/&" is not a typo, the contents of

  /ifs/isi1/ufr/nfs/denbi

will be available under the path

  /ifs/isi1/ufr/bronze/nfs/denbi/dnb01

after the move.

Ping @erasche @bgruening 