### PR TITLE
Additional mountpoints for /data

### DIFF
--- a/ansible-roles/group_vars/all.yml
+++ b/ansible-roles/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-vg_build: 29
+vg_build: 30
 # This will be replaced by jenkins.
 vg_build_tag:  vggp-v##-j##-##-branch
 

--- a/conf/auto.data
+++ b/conf/auto.data
@@ -7,4 +7,7 @@
 6       -rw,hard,intr,nosuid,quota      sn03.bi.uni-freiburg.de:/export/galaxy1/data/&
 7       -rw,hard,intr,nosuid,quota      sn03.bi.uni-freiburg.de:/export/galaxy1/data/&
 dnb01   -rw,hard,intr,nosuid,quota      ufr.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
+dnb02   -rw,hard,intr,nosuid,quota      ufr.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
+dnb03   -rw,hard,intr,nosuid,quota      ufr.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
+dnb04   -rw,hard,intr,nosuid,quota      ufr.isi1.public.ads.uni-freiburg.de:/ifs/isi1/ufr/bronze/nfs/denbi/&
 db      -rw,hard,intr,nosuid,quota      sn02.bi.uni-freiburg.de:/export/fdata1/galaxy/net/data/&


### PR DESCRIPTION
This PR creates three new automount points under `/data`: `/data/dnb0{2,3,4}`. The directories these automount points refer to are on the same file system as `/data/dnb01`.

The purpose is to allow for a  _logical_ partitioning of the _name space_ of the files created (via Galaxy data spaces) in order to facilitate future migration of the data (which __will__ become necessary one day).

Note that there is no physical fragmentation of the data space; so no space can be lost.

Ping @erasche @bgruening 