### PR TITLE
Update rockylinux-8.x-x86_64.json

### DIFF
--- a/rockylinux-8.x-x86_64.json
+++ b/rockylinux-8.x-x86_64.json
@@ -1,58 +1,57 @@
 {
-  "variables": {
-    "http_dir": "http",
-    "iso_checksum": "fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
-    "iso_checksum_type": "sha256",
-    "iso_checksum_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/CHECKSUM",
-    "iso_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/Rocky-8.6-x86_64-boot.iso",
-    "kickstart_path": "rockylinux-8.x/anaconda-ks.cfg",
-    "shutdown_command": "systemctl poweroff",
-    "ssh_password": "password",
-    "vm_name": "rockylinux-8.x-x86_64"
-  },
-  "builders": [
-    {
-      "accelerator": "kvm",
-      "boot_command": [
-        "<esc><wait>",
-        "linux inst.mbr biosdevname=0 net.ifnames=0 ",
-        "rootpw={{ user `ssh_password` }} ",
-        "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `kickstart_path` }}",
-        "<enter>"
-      ],
-      "boot_wait": "{{ user `boot_wait` }}",
-      "disk_interface": "virtio",
-      "disk_size": "{{ user `disk_size` }}",
-      "format": "qcow2",
-      "headless": "{{ user `headless` }}",
-      "http_directory": "{{ user `http_dir` }}",
-      "iso_checksum": "{{ user `iso_checksum_type` }}:{{ user `iso_checksum` }}",
-      "iso_url": "{{ user `iso_url` }}",
-      "net_device": "virtio-net",
-      "output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
-      "qemuargs": [
-        [
-          "-m",
-          "{{ user `memory` }}"
-        ],
-        [
-          "-smp",
-          "{{ user `cpus` }}"
-        ]
-      ],
-      "shutdown_command": "{{ user `shutdown_command` }}",
-      "ssh_password": "{{ user `ssh_password` }}",
-      "ssh_timeout": "{{ user `ssh_timeout` }}",
-      "ssh_username": "{{ user `ssh_username` }}",
-      "type": "qemu",
-      "vm_name": "{{ user `vm_name` }}"
-    }
-  ],
-  "post-processors": [
-    {
-      "output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json",
-      "type": "manifest"
-    }
-  ]
+	"variables": {
+		"http_dir": "http",
+		"iso_checksum": "fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
+		"iso_checksum_type": "sha256",
+		"iso_checksum_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/CHECKSUM",
+		"iso_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/Rocky-8.6-x86_64-boot.iso",
+		"kickstart_path": "rockylinux-8.x/anaconda-ks.cfg",
+		"shutdown_command": "systemctl poweroff",
+		"ssh_password": "password",
+		"vm_name": "rockylinux-8.x-x86_64"
+	},
+	"builders": [
+		{
+			"accelerator": "kvm",
+			"boot_command": [
+				"<esc><wait>",
+				"linux inst.mbr biosdevname=0 net.ifnames=0 ",
+				"rootpw={{ user `ssh_password` }} ",
+				"inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `kickstart_path` }}",
+				"<enter>"
+			],
+			"boot_wait": "{{ user `boot_wait` }}",
+			"disk_interface": "virtio",
+			"disk_size": "{{ user `disk_size` }}",
+			"format": "qcow2",
+			"headless": "{{ user `headless` }}",
+			"http_directory": "{{ user `http_dir` }}",
+			"iso_checksum": "{{ user `iso_checksum_type` }}:{{ user `iso_checksum` }}",
+			"iso_url": "{{ user `iso_url` }}",
+			"net_device": "virtio-net",
+			"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
+			"qemuargs": [
+				[
+					"-m",
+					"{{ user `memory` }}"
+				],
+				[
+					"-smp",
+					"{{ user `cpus` }}"
+				]
+			],
+			"shutdown_command": "{{ user `shutdown_command` }}",
+			"ssh_password": "{{ user `ssh_password` }}",
+			"ssh_timeout": "{{ user `ssh_timeout` }}",
+			"ssh_username": "{{ user `ssh_username` }}",
+			"type": "qemu",
+			"vm_name": "{{ user `vm_name` }}"
+		}
+	],
+	"post-processors": [
+		{
+			"output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json",
+			"type": "manifest"
+		}
+	]
 }
-

--- a/rockylinux-8.x-x86_64.json
+++ b/rockylinux-8.x-x86_64.json
@@ -10,48 +10,44 @@
 		"ssh_password": "password",
 		"vm_name": "rockylinux-8.x-x86_64"
 	},
-	"builders": [
-		{
-			"accelerator": "kvm",
-			"boot_command": [
-				"<esc><wait>",
-				"linux inst.mbr biosdevname=0 net.ifnames=0 ",
-				"rootpw={{ user `ssh_password` }} ",
-				"inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `kickstart_path` }}",
-				"<enter>"
+	"builders": [{
+		"accelerator": "kvm",
+		"boot_command": [
+			"<esc><wait>",
+			"linux inst.mbr biosdevname=0 net.ifnames=0 ",
+			"rootpw={{ user `ssh_password` }} ",
+			"inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `kickstart_path` }}",
+			"<enter>"
+		],
+		"boot_wait": "{{ user `boot_wait` }}",
+		"disk_interface": "virtio",
+		"disk_size": "{{ user `disk_size` }}",
+		"format": "qcow2",
+		"headless": "{{ user `headless` }}",
+		"http_directory": "{{ user `http_dir` }}",
+		"iso_checksum": "{{ user `iso_checksum_type` }}:{{ user `iso_checksum` }}",
+		"iso_url": "{{ user `iso_url` }}",
+		"net_device": "virtio-net",
+		"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
+		"qemuargs": [
+			[
+				"-m",
+				"{{ user `memory` }}"
 			],
-			"boot_wait": "{{ user `boot_wait` }}",
-			"disk_interface": "virtio",
-			"disk_size": "{{ user `disk_size` }}",
-			"format": "qcow2",
-			"headless": "{{ user `headless` }}",
-			"http_directory": "{{ user `http_dir` }}",
-			"iso_checksum": "{{ user `iso_checksum_type` }}:{{ user `iso_checksum` }}",
-			"iso_url": "{{ user `iso_url` }}",
-			"net_device": "virtio-net",
-			"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
-			"qemuargs": [
-				[
-					"-m",
-					"{{ user `memory` }}"
-				],
-				[
-					"-smp",
-					"{{ user `cpus` }}"
-				]
-			],
-			"shutdown_command": "{{ user `shutdown_command` }}",
-			"ssh_password": "{{ user `ssh_password` }}",
-			"ssh_timeout": "{{ user `ssh_timeout` }}",
-			"ssh_username": "{{ user `ssh_username` }}",
-			"type": "qemu",
-			"vm_name": "{{ user `vm_name` }}"
-		}
-	],
-	"post-processors": [
-		{
-			"output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json",
-			"type": "manifest"
-		}
-	]
+			[
+				"-smp",
+				"{{ user `cpus` }}"
+			]
+		],
+		"shutdown_command": "{{ user `shutdown_command` }}",
+		"ssh_password": "{{ user `ssh_password` }}",
+		"ssh_timeout": "{{ user `ssh_timeout` }}",
+		"ssh_username": "{{ user `ssh_username` }}",
+		"type": "qemu",
+		"vm_name": "{{ user `vm_name` }}"
+	}],
+	"post-processors": [{
+		"output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json",
+		"type": "manifest"
+	}]
 }

--- a/rockylinux-8.x-x86_64.json
+++ b/rockylinux-8.x-x86_64.json
@@ -36,14 +36,8 @@
 		"ssh_password": "{{ user `ssh_password` }}",
 		"shutdown_command": "{{ user `shutdown_command` }}",
 		"qemuargs": [
-			[
-				"-m",
-				"{{ user `memory` }}"
-			],
-			[
-				"-smp",
-				"{{ user `cpus` }}"
-			]
+			["-m", "{{ user `memory` }}"],
+			["-smp", "{{ user `cpus` }}"]
 		]
 	}],
 	"post-processors": [{

--- a/rockylinux-8.x-x86_64.json
+++ b/rockylinux-8.x-x86_64.json
@@ -1,48 +1,58 @@
 {
-	"variables": {
-		"iso_url": "https://ftp.fau.de/rockylinux/8.6/isos/x86_64/Rocky-8.6-x86_64-boot.iso",
-		"iso_checksum": "fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
-		"iso_checksum_url": "https://ftp.fau.de/rockylinux/8.6/isos/x86_64/CHECKSUM",
-		"iso_checksum_type": "sha256",
-		"vm_name": "rockylinux-8.x-x86_64",
-		"http_dir": "http",
-		"kickstart_path": "rockylinux-8.x/anaconda-ks.cfg",
-		"shutdown_command": "systemctl poweroff",
-		"ssh_password": "password"
-	},
-	"builders": [{
-		"type": "qemu",
-		"accelerator": "kvm",
-		"iso_url": "{{ user `iso_url` }}",
-		"iso_checksum": "{{ user `iso_checksum` }}",
-		"iso_checksum_type": "{{ user `iso_checksum_type` }}",
-		"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
-		"vm_name": "{{ user `vm_name` }}",
-		"format": "qcow2",
-		"disk_size": "{{ user `disk_size` }}",
-		"net_device": "virtio-net",
-		"disk_interface": "virtio",
-		"headless": "{{ user `headless` }}",
-		"http_directory": "{{ user `http_dir` }}",
-		"boot_command": [
-			"<esc><wait>",
-			"linux inst.mbr biosdevname=0 net.ifnames=0 ",
-			"rootpw={{ user `ssh_password` }} ",
-			"inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `kickstart_path` }}",
-			"<enter>"
-		],
-		"boot_wait": "{{ user `boot_wait` }}",
-		"ssh_timeout": "{{ user `ssh_timeout` }}",
-		"ssh_username": "{{ user `ssh_username` }}",
-		"ssh_password": "{{ user `ssh_password` }}",
-		"shutdown_command": "{{ user `shutdown_command` }}",
-		"qemuargs": [
-			["-m", "{{ user `memory` }}"],
-			["-smp", "{{ user `cpus` }}"]
-		]
-	}],
-	"post-processors": [{
-		"type": "manifest",
-		"output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json"
-	}]
+  "builders": [
+    {
+      "accelerator": "kvm",
+      "boot_command": [
+        "<esc><wait>",
+        "linux inst.mbr biosdevname=0 net.ifnames=0 ",
+        "rootpw={{ user `ssh_password` }} ",
+        "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `kickstart_path` }}",
+        "<enter>"
+      ],
+      "boot_wait": "{{ user `boot_wait` }}",
+      "disk_interface": "virtio",
+      "disk_size": "{{ user `disk_size` }}",
+      "format": "qcow2",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "{{ user `http_dir` }}",
+      "iso_checksum": "{{ user `iso_checksum_type` }}:{{ user `iso_checksum` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "net_device": "virtio-net",
+      "output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
+      "qemuargs": [
+        [
+          "-m",
+          "{{ user `memory` }}"
+        ],
+        [
+          "-smp",
+          "{{ user `cpus` }}"
+        ]
+      ],
+      "shutdown_command": "{{ user `shutdown_command` }}",
+      "ssh_password": "{{ user `ssh_password` }}",
+      "ssh_timeout": "{{ user `ssh_timeout` }}",
+      "ssh_username": "{{ user `ssh_username` }}",
+      "type": "qemu",
+      "vm_name": "{{ user `vm_name` }}"
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json",
+      "type": "manifest"
+    }
+  ],
+  "variables": {
+    "http_dir": "http",
+    "iso_checksum": "fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
+    "iso_checksum_type": "sha256",
+    "iso_checksum_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/CHECKSUM",
+    "iso_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/Rocky-8.6-x86_64-boot.iso",
+    "kickstart_path": "rockylinux-8.x/anaconda-ks.cfg",
+    "shutdown_command": "systemctl poweroff",
+    "ssh_password": "password",
+    "vm_name": "rockylinux-8.x-x86_64"
+  }
 }
+

--- a/rockylinux-8.x-x86_64.json
+++ b/rockylinux-8.x-x86_64.json
@@ -1,17 +1,28 @@
 {
 	"variables": {
-		"http_dir": "http",
-		"iso_checksum": "fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
-		"iso_checksum_type": "sha256",
-		"iso_checksum_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/CHECKSUM",
 		"iso_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/Rocky-8.6-x86_64-boot.iso",
+		"iso_checksum": "fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
+		"iso_checksum_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/CHECKSUM",
+		"iso_checksum_type": "sha256",
+		"vm_name": "rockylinux-8.x-x86_64",
+		"http_dir": "http",
 		"kickstart_path": "rockylinux-8.x/anaconda-ks.cfg",
 		"shutdown_command": "systemctl poweroff",
-		"ssh_password": "password",
-		"vm_name": "rockylinux-8.x-x86_64"
+		"ssh_password": "password"
 	},
 	"builders": [{
+		"type": "qemu",
 		"accelerator": "kvm",
+		"iso_url": "{{ user `iso_url` }}",
+		"iso_checksum": "{{ user `iso_checksum_type` }}:{{ user `iso_checksum` }}",
+		"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
+		"vm_name": "{{ user `vm_name` }}",
+		"format": "qcow2",
+		"disk_size": "{{ user `disk_size` }}",
+		"net_device": "virtio-net",
+		"disk_interface": "virtio",
+		"headless": "{{ user `headless` }}",
+		"http_directory": "{{ user `http_dir` }}",
 		"boot_command": [
 			"<esc><wait>",
 			"linux inst.mbr biosdevname=0 net.ifnames=0 ",
@@ -20,15 +31,10 @@
 			"<enter>"
 		],
 		"boot_wait": "{{ user `boot_wait` }}",
-		"disk_interface": "virtio",
-		"disk_size": "{{ user `disk_size` }}",
-		"format": "qcow2",
-		"headless": "{{ user `headless` }}",
-		"http_directory": "{{ user `http_dir` }}",
-		"iso_checksum": "{{ user `iso_checksum_type` }}:{{ user `iso_checksum` }}",
-		"iso_url": "{{ user `iso_url` }}",
-		"net_device": "virtio-net",
-		"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
+		"ssh_timeout": "{{ user `ssh_timeout` }}",
+		"ssh_username": "{{ user `ssh_username` }}",
+		"ssh_password": "{{ user `ssh_password` }}",
+		"shutdown_command": "{{ user `shutdown_command` }}",
 		"qemuargs": [
 			[
 				"-m",
@@ -38,16 +44,10 @@
 				"-smp",
 				"{{ user `cpus` }}"
 			]
-		],
-		"shutdown_command": "{{ user `shutdown_command` }}",
-		"ssh_password": "{{ user `ssh_password` }}",
-		"ssh_timeout": "{{ user `ssh_timeout` }}",
-		"ssh_username": "{{ user `ssh_username` }}",
-		"type": "qemu",
-		"vm_name": "{{ user `vm_name` }}"
+		]
 	}],
 	"post-processors": [{
-		"output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json",
-		"type": "manifest"
+		"type": "manifest",
+		"output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json"
 	}]
 }

--- a/rockylinux-8.x-x86_64.json
+++ b/rockylinux-8.x-x86_64.json
@@ -1,4 +1,15 @@
 {
+  "variables": {
+    "http_dir": "http",
+    "iso_checksum": "fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
+    "iso_checksum_type": "sha256",
+    "iso_checksum_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/CHECKSUM",
+    "iso_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/Rocky-8.6-x86_64-boot.iso",
+    "kickstart_path": "rockylinux-8.x/anaconda-ks.cfg",
+    "shutdown_command": "systemctl poweroff",
+    "ssh_password": "password",
+    "vm_name": "rockylinux-8.x-x86_64"
+  },
   "builders": [
     {
       "accelerator": "kvm",
@@ -42,17 +53,6 @@
       "output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json",
       "type": "manifest"
     }
-  ],
-  "variables": {
-    "http_dir": "http",
-    "iso_checksum": "fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
-    "iso_checksum_type": "sha256",
-    "iso_checksum_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/CHECKSUM",
-    "iso_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/Rocky-8.6-x86_64-boot.iso",
-    "kickstart_path": "rockylinux-8.x/anaconda-ks.cfg",
-    "shutdown_command": "systemctl poweroff",
-    "ssh_password": "password",
-    "vm_name": "rockylinux-8.x-x86_64"
-  }
+  ]
 }
 


### PR DESCRIPTION
Fixes the Rocky Linux template for current Packer release and also updates the path to the ISO, as specified here: https://ftp.fau.de/rockylinux/8.6/README.txt

More info can be found here: https://github.com/usegalaxy-eu/vgcn-infrastructure/issues/178
