### PR TITLE
add PACKER_PATH env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,16 @@
 # 	* support building with non-qemu builders and convert to qemu afterwards
 # 	* testing target
 # 	* auto-detect flavors
-PACKER := $(shell which packer)
-ifndef PACKER
-$(error packer not found, please install it)
+
+ifndef ${PACKER_PATH}
+        PACKER := ${PACKER_PATH}
+else
+        PACKER := $(shell which packer)
 endif
+ifndef PACKER
+	$(error packer not found, please install it)
+endif
+
 
 ANSIBLE_DIR=ansible-roles
 # the "provisioning" flavor, expects a 'setup-<flavor>.yml' playbook


### PR DESCRIPTION
Because of RHEL's faulty /usr/sbin/packer
This should solve the problem, we only need to export `PACKER_PATH=/usr/bin/packer` in Jenkins