### PR TITLE
Removed deprecated `iso_checksum_type`

### DIFF
--- a/centos-7.x-x86_64.json
+++ b/centos-7.x-x86_64.json
@@ -1,9 +1,8 @@
 {
 	"variables": {
 		"iso_url": "http://mirror1.hs-esslingen.de/pub/Mirrors/centos/7/isos/x86_64/CentOS-7-x86_64-NetInstall-2003.iso",
-		"iso_checksum": "101bc813d2af9ccf534d112cbe8670e6d900425b297d1a4d2529c5ad5f226372",
+		"iso_checksum": "sha256:101bc813d2af9ccf534d112cbe8670e6d900425b297d1a4d2529c5ad5f226372",
 		"iso_checksum_url": "http://mirror1.hs-esslingen.de/pub/Mirrors/centos/7/isos/x86_64/sha256sum.txt", 
-		"iso_checksum_type": "sha256",
 		"vm_name": "centos-7.x-x86_64",
 		"http_dir": "http",
 		"kickstart_path": "centos-7.x/anaconda-ks.cfg",
@@ -15,7 +14,6 @@
 		"accelerator": "kvm",
 		"iso_url": "{{ user `iso_url` }}",
 		"iso_checksum": "{{ user `iso_checksum` }}",
-		"iso_checksum_type": "{{ user `iso_checksum_type` }}",
 		"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
 		"vm_name": "{{ user `vm_name` }}",
 		"format": "qcow2",

--- a/centos-8.x-x86_64.json
+++ b/centos-8.x-x86_64.json
@@ -1,9 +1,8 @@
 {
 	"variables": {
 		"iso_url": "https://vault.centos.org/8.5.2111/isos/x86_64/CentOS-8.5.2111-x86_64-boot.iso",
-		"iso_checksum": "9602c69c52d93f51295c0199af395ca0edbe35e36506e32b8e749ce6c8f5b60a",
+		"iso_checksum": "sha256:9602c69c52d93f51295c0199af395ca0edbe35e36506e32b8e749ce6c8f5b60a",
 		"iso_checksum_url": "https://vault.centos.org/8.5.2111/isos/x86_64/CHECKSUM",
-		"iso_checksum_type": "sha256",
 		"vm_name": "centos-8.x-x86_64",
 		"http_dir": "http",
 		"kickstart_path": "centos-8.x/anaconda-ks.cfg",
@@ -15,7 +14,6 @@
 		"accelerator": "kvm",
 		"iso_url": "{{ user `iso_url` }}",
 		"iso_checksum": "{{ user `iso_checksum` }}",
-		"iso_checksum_type": "{{ user `iso_checksum_type` }}",
 		"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
 		"vm_name": "{{ user `vm_name` }}",
 		"format": "qcow2",

--- a/rockylinux-8.x-x86_64.json
+++ b/rockylinux-8.x-x86_64.json
@@ -1,9 +1,8 @@
 {
 	"variables": {
 		"iso_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/Rocky-8.6-x86_64-boot.iso",
-		"iso_checksum": "fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
+		"iso_checksum": "sha256:fe77cc293a2f2fe6ddbf5d4bc2b5c820024869bc7ea274c9e55416d215db0cc5",
 		"iso_checksum_url": "https://dl.rockylinux.org/vault/rocky/8.6/isos/x86_64/CHECKSUM",
-		"iso_checksum_type": "sha256",
 		"vm_name": "rockylinux-8.x-x86_64",
 		"http_dir": "http",
 		"kickstart_path": "rockylinux-8.x/anaconda-ks.cfg",
@@ -14,7 +13,7 @@
 		"type": "qemu",
 		"accelerator": "kvm",
 		"iso_url": "{{ user `iso_url` }}",
-		"iso_checksum": "{{ user `iso_checksum_type` }}:{{ user `iso_checksum` }}",
+		"iso_checksum": "{{ user `iso_checksum` }}",
 		"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
 		"vm_name": "{{ user `vm_name` }}",
 		"format": "qcow2",


### PR DESCRIPTION
now checksums are in the format "checksumType:Checksum"