### PR TITLE
Add 'become' user to the fslimit role

### DIFF
--- a/ansible-roles/setup-vgcn-bwcloud-gpu.yml
+++ b/ansible-roles/setup-vgcn-bwcloud-gpu.yml
@@ -139,6 +139,7 @@
 
     # Applies a 250GB soft and 1TB hard limit on the file size for the condor systemd unit
     - role: usegalaxy-eu.fslimit
+      become: yes
       vars:
         ulimit_fsize_unit: "condor.service"
         ulimit_fsize_soft: 268435456000

--- a/ansible-roles/setup-vgcn-bwcloud-secure.yml
+++ b/ansible-roles/setup-vgcn-bwcloud-secure.yml
@@ -139,6 +139,7 @@
 
     # Applies a 250GB soft and 1TB hard limit on the file size for the condor systemd unit
     - role: usegalaxy-eu.fslimit
+      become: yes
       vars:
         ulimit_fsize_unit: "condor.service"
         ulimit_fsize_soft: 268435456000

--- a/ansible-roles/setup-vgcn-bwcloud.yml
+++ b/ansible-roles/setup-vgcn-bwcloud.yml
@@ -140,6 +140,7 @@
 
     # Applies a 250GB soft and 1TB hard limit on the file size for the condor systemd unit
     - role: usegalaxy-eu.fslimit
+      become: yes
       vars:
         ulimit_fsize_unit: "condor.service"
         ulimit_fsize_soft: 268435456000


### PR DESCRIPTION
Stefan's fslimit role require `become` user to create the directory and the service unit file.