### PR TITLE
downgrade to ansible 6.7.0

### DIFF
--- a/ansible-roles/dj-wasabi.telegraf/requirements.txt
+++ b/ansible-roles/dj-wasabi.telegraf/requirements.txt
@@ -1,4 +1,4 @@
-ansible==7.0.0
+ansible==6.7.0
 docker==3.3.0
 molecule==2.13.1
 testinfra==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==7.0.0
+ansible==6.7.0
 python-openstackclient==3.14.0


### PR DESCRIPTION
Ansible 7.0.0 is not available in EL repos yet
here is a explanation how the ansible versioning works:
[https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html)