### PR TITLE
Update anaconda-ks.cfg

### DIFF
--- a/http/rockylinux-9.x/anaconda-ks.cfg
+++ b/http/rockylinux-9.x/anaconda-ks.cfg
@@ -52,8 +52,9 @@ ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 <<EOF
 
 # Use cgroups v1 because cgroups v2 do not count total memory usage yet (5/2023)
-awk -i inplace '/GRUB_CMDLINE_LINUX/{sub("\"$", " systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller=1\"")}1' /etc/default/grub
-update-grub
+awk -i inplace '/GRUB_CMDLINE_LINUX_DEFAULT/{sub("\"$", " systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller=1\"")}1' /etc/default/grub
+grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg
+
 
 DEVICE="eth0"
 BOOTPROTO="dhcp"


### PR DESCRIPTION
fixes the cgroups downgrade command in kickstart, discovered and implemented by @sanjaysrikakulam 