### PR TITLE
Add Alma Linux 8 cloud image

### DIFF
--- a/almacloud-8.x-x86_64.json
+++ b/almacloud-8.x-x86_64.json
@@ -1,0 +1,59 @@
+{
+	"variables": {
+		"iso_url": "https://mirror.hs-esslingen.de/Mirrors/almalinux/8/isos/x86_64/AlmaLinux-8-latest-x86_64-boot.iso",
+		"iso_checksum": "sha256:016e59963c2c3bd4c99c18ac957573968e23da51131104568fbf389b11df3e05",
+		"iso_checksum_url": "https://mirror.hs-esslingen.de/Mirrors/almalinux/8/cloud/x86_64/images/CHECKSUM",
+		"vm_name": "almacloud-8.x-x86_64",
+		"http_dir": "http",
+		"kickstart_path": "almacloud-8.x/anaconda-ks.cfg",
+		"shutdown_command": "systemctl poweroff",
+		"ssh_password": "password"
+	},
+	"builders": [
+		{
+			"type": "qemu",
+			"accelerator": "kvm",
+			"iso_url": "{{ user `iso_url` }}",
+			"iso_checksum": "{{ user `iso_checksum` }}",
+			"output_directory": "output-{{ user `vm_name` }}-{{ build_type }}",
+			"vm_name": "{{ user `vm_name` }}",
+			"format": "qcow2",
+			"disk_size": "10G",
+			"disk_interface": "virtio-scsi",
+			"disk_cache": "unsafe",
+			"disk_discard": "unmap",
+			"disk_detect_zeroes": "unmap",
+			"disk_compression": true,
+			"net_device": "virtio-net",
+			"headless": "{{ user `headless` }}",
+			"http_directory": "{{ user `http_dir` }}",
+			"boot_wait": "10s",
+			"ssh_timeout": "{{ user `ssh_timeout` }}",
+			"ssh_username": "{{ user `ssh_username` }}",
+			"ssh_password": "{{ user `ssh_password` }}",
+			"shutdown_command": "{{ user `shutdown_command` }}",
+			"qemuargs": [
+				[
+					"-m",
+					"{{ user `memory` }}"
+				],
+				[
+					"-smp",
+					"{{ user `cpus` }}"
+				]
+			],
+			"boot_command": [
+				"<tab>",
+				"inst.text net.ifnames=0 inst.gpt",
+				" inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{ user `kickstart_path` }}",
+				"<enter><wait>"
+			]
+		}
+	],
+	"post-processors": [
+		{
+			"type": "manifest",
+			"output": "output-{{ user `vm_name` }}-{{ build_type }}/manifest.json"
+		}
+	]
+}

--- a/ansible-roles/group_vars/condor.yml
+++ b/ansible-roles/group_vars/condor.yml
@@ -1,2 +1,3 @@
 ---
+condor_package_label: "{{ condor-all-8.8.15 if ansible_facts['distribution_major_version']|int < 9 | default(omit) }}"
 condor_copy_template: false

--- a/ansible-roles/internal.yml
+++ b/ansible-roles/internal.yml
@@ -22,6 +22,12 @@
         - rsa
         - ecdsa
         - ed25519
+    - name: Add core limit
+      community.general.pam_limits:
+        domain: galaxy
+        limit_type: hard
+        limit_item: core
+        value: 0
   roles:
     - usegalaxy_eu.htcondor
     - lock-root

--- a/ansible-roles/internal.yml
+++ b/ansible-roles/internal.yml
@@ -4,6 +4,7 @@
     internal: true
   vars_files:
     - "group_vars/all.yml"
+    - "group_vars/condor.yml"
     - "secret_group_vars/internal.yml"
   pre_tasks:
     - name: Copy server key into VM temporarily

--- a/ansible-roles/setup-vgcn-bwcloud.yml
+++ b/ansible-roles/setup-vgcn-bwcloud.yml
@@ -2,37 +2,49 @@
 # This setup is valid for RHEL 9.x based systems.
 # It has SELinux permissive and firewalld enabled
 ---
-- hosts: default
+- name: Setup VGCN compute node
+  hosts: default
   vars_files:
     - "group_vars/all.yml"
     - "group_vars/grub.yml"
     - "group_vars/pulsar.yml"
     - "group_vars/condor.yml"
   pre_tasks:
-    - name: system update
+    - name: System update
       ansible.builtin.dnf:
         name: "*"
         state: latest
         exclude: condor*
     - name: Install Pulsar dependencies
-      package:
+      ansible.builtin.package:
         name:
           - git
           - virtualenv
           - python3
+          - python3-pycurl
+          - yum
+          - openssl
+          - openssl-devel
+        state: present
       become: true
       when: ansible_os_family == 'Debian'
     - name: Install Pulsar dependencies
-      package:
+      ansible.builtin.package:
         name:
           - git
-          - python36-virtualenv
+          - python3-virtualenv
           - python3
+          - python3-pycurl
+          - yum
+          - libcurl-devel
+          - python3-libs
+          - openssl
+          - openssl-devel
         state: present
       become: true
       when: ansible_os_family == 'RedHat' and ansible_distribution_major_version | int == 8
     - name: Install Pulsar dependencies
-      package:
+      ansible.builtin.package:
         name:
           - git
           - libcurl-devel
@@ -41,7 +53,7 @@
       become: true
       when: ansible_os_family == 'RedHat' and ansible_distribution_major_version | int == 9
     - name: Set default version of Python
-      ansible.builtin.alternatives:
+      community.general.alternatives:
         name: python
         path: /usr/bin/python3
         link: /usr/bin/python
@@ -58,7 +70,7 @@
         dest: /usr/bin/docker-stop-1M
         owner: root
         group: root
-        mode: 0755
+        mode: '0755'
   post_tasks:
     - name: Add firewall rules for NFS
       ansible.posix.firewalld:
@@ -74,11 +86,13 @@
       ansible.builtin.service:
         name: autofs
         state: restarted
-    - ansible.builtin.user:
+    - name: Add groups to Galaxy user
+      ansible.builtin.user:
         name: galaxy
         groups: condor,docker
-        append: yes
-    - ansible.builtin.dnf:
+        append: true
+    - name: Remove packages
+      ansible.builtin.dnf:
         name: "{{ packages }}"
         state: absent
       vars:
@@ -86,9 +100,9 @@
           - gcc
           - libcurl-devel
           - openssl-devel
-      become: yes
+      become: true
     - name: Ensure Docker directory extists
-      file:
+      ansible.builtin.file:
         state: directory
         path: /etc/docker
         mode: '0755'
@@ -109,7 +123,7 @@
         dest: /bin/iamalive
         owner: telegraf
         group: telegraf
-        mode: 0755
+        mode: '0755'
   roles:
     - geerlingguy.repo-epel # Install EPEL
     - role: usegalaxy_eu.handy.os_setup
@@ -127,13 +141,10 @@
 
     - usegalaxy-eu.autofs
     - usegalaxy-eu.dynmotd
-
     - geerlingguy.java
     - geerlingguy.docker
-
     - influxdata.chrony
     - dj-wasabi.telegraf
-
     - galaxyproject.cvmfs
     - galaxyproject.pulsar
     - usegalaxy-eu.logrotate
@@ -151,7 +162,7 @@
 
     # Applies a 250GB soft and 1TB hard limit on the file size for the condor systemd unit
     - role: usegalaxy-eu.fslimit
-      become: yes
+      become: true
       vars:
         ulimit_fsize_unit: "condor.service"
         ulimit_fsize_soft: 268435456000

--- a/ansible-roles/setup-vgcn-bwcloud.yml
+++ b/ansible-roles/setup-vgcn-bwcloud.yml
@@ -82,6 +82,13 @@
         - nfs
         - rpc-bind
         - mountd
+        - name: Add firewall rules for NFS
+    - name: Open Port for HTCondor
+      ansible.posix.firewalld:
+        port: 9618/tcp
+        state: enabled
+        permanent: true
+        immediate: true
     - name: Restart Autofs
       ansible.builtin.service:
         name: autofs

--- a/ansible-roles/setup-vgcn-bwcloud.yml
+++ b/ansible-roles/setup-vgcn-bwcloud.yml
@@ -144,7 +144,7 @@
     - geerlingguy.java
     - geerlingguy.docker
     - influxdata.chrony
-    - usegalaxy_eu.telegraf
+    - usegalaxy-eu.telegraf
     - galaxyproject.cvmfs
     - galaxyproject.pulsar
     - usegalaxy-eu.logrotate

--- a/ansible-roles/setup-vgcn-bwcloud.yml
+++ b/ansible-roles/setup-vgcn-bwcloud.yml
@@ -82,7 +82,6 @@
         - nfs
         - rpc-bind
         - mountd
-        - name: Add firewall rules for NFS
     - name: Open Port for HTCondor
       ansible.posix.firewalld:
         port: 9618/tcp

--- a/ansible-roles/setup-vgcn-bwcloud.yml
+++ b/ansible-roles/setup-vgcn-bwcloud.yml
@@ -144,7 +144,7 @@
     - geerlingguy.java
     - geerlingguy.docker
     - influxdata.chrony
-    - dj-wasabi.telegraf
+    - usegalaxy_eu.telegraf
     - galaxyproject.cvmfs
     - galaxyproject.pulsar
     - usegalaxy-eu.logrotate

--- a/base.json
+++ b/base.json
@@ -1,7 +1,7 @@
 {
   "cpus": "2",
-  "boot_wait": "15s",
-  "disk_size": "6000",
+  "boot_wait": "10s",
+  "disk_size": "10G",
   "headless": "true",
   "memory": "2048",
   "ssh_timeout": "600m",

--- a/http/almacloud-8.x/anaconda-ks.cfg
+++ b/http/almacloud-8.x/anaconda-ks.cfg
@@ -1,0 +1,59 @@
+# AlmaLinux 8 kickstart file for Generic Cloud (OpenStack) image
+
+url --url https://mirror.hs-esslingen.de/Mirrors/almalinux/8/BaseOS/x86_64/kickstart/
+repo --name=BaseOS --baseurl=https://mirror.hs-esslingen.de/Mirrors/almalinux/8/BaseOS/x86_64/os/
+repo --name=AppStream --baseurl=https://mirror.hs-esslingen.de/Mirrors/almalinux/8/AppStream/x86_64/os/
+repo --name=epel --baseurl=http://ftp.uni-stuttgart.de/epel/8/Everything/x86_64/
+
+text
+skipx
+eula --agreed
+firstboot --disabled
+
+lang en_US.UTF-8
+keyboard us
+timezone UTC --isUtc
+
+network --bootproto=dhcp
+firewall --enabled --service=ssh
+services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
+selinux --enforcing
+
+# TODO: remove "console=tty0" from here
+bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 no_timer_check" --location=mbr --timeout=1
+zerombr
+clearpart --all --initlabel
+reqpart
+part / --fstype="xfs" --size=8000
+
+rootpw --plaintext password
+
+reboot --eject
+
+
+%packages
+@core
+-biosdevname
+-open-vm-tools
+-plymouth
+-dnf-plugin-spacewalk
+-rhn*
+-iprutils
+-iwl*-firmware
+-epel-release
+-ansible
+%end
+
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end
+
+
+%post
+/usr/sbin/rhnreg_ks --activationkey=$ACTIVATIONKEY
+rpm --import /usr/share/rhn/RPM-GPG-KEY
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release-2
+%end

--- a/requirements.yml
+++ b/requirements.yml
@@ -14,7 +14,7 @@ roles:
   - src: usegalaxy_eu.cuda
     version: 1.1.0
   - src: usegalaxy_eu.nvidia_container
-    version: 1.1.0
+    version: 1.2.0
   - src: geerlingguy.docker
     version: 6.1.0
   - src: https://github.com/usegalaxy-eu/ansible-chrony
@@ -27,7 +27,7 @@ roles:
     version:
       0.0.1
   - name: usegalaxy_eu.htcondor
-    version: 2.1.0
+    version: 2.2.0
   - src: geerlingguy.repo-epel
     version: 3.1.0
   - src: geerlingguy.java
@@ -43,5 +43,5 @@ roles:
   - name: usegalaxy-eu.fslimit
     src: https://github.com/usegalaxy-eu/ansible-fslimit
     version: main
-  - name: dj-wasabi.telegraf
-    version: 0.14.0
+  - name: usegalaxy-eu.telegraf
+    version: 0.14.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -44,4 +44,6 @@ roles:
     src: https://github.com/usegalaxy-eu/ansible-fslimit
     version: main
   - name: usegalaxy-eu.telegraf
+    src: https://github.com/usegalaxy-eu/ansible-telegraf
     version: 0.14.1
+


### PR DESCRIPTION
Create an Alma Linux 8 cloud image.

Following changes were made, that affect also other images:
- `disk_size` increased to 10G for all images (required by Almalinux and difficult so separate in run-playbook-only.json)
- use `usegalaxy-eu.telegraf` fork instead of `dj-wasabi`
- use old usegalaxy_eu.htcondor role for RHEL 8 distros (group_vars/all.yml)
- packages added to `setup-vgcn-bwcloud.yml` playbook.