### PR TITLE
add missing packages

### DIFF
--- a/ansible-roles/setup-vgcn-bwcloud.yml
+++ b/ansible-roles/setup-vgcn-bwcloud.yml
@@ -19,25 +19,17 @@
       ansible.builtin.package:
         name:
           - git
-          - virtualenv
-          - python3
-          - python3-pycurl
-          - yum
-          - openssl
-          - openssl-devel
-        state: present
-      become: true
-      when: ansible_os_family == 'Debian'
-    - name: Install Pulsar dependencies
-      ansible.builtin.package:
-        name:
-          - git
           - python3-virtualenv
           - python3
           - python3-pycurl
+          - python3-devel
           - yum
+          - gcc
+          - curl
           - libcurl-devel
           - python3-libs
+          - python38
+          - python38-devel
           - openssl
           - openssl-devel
         state: present


### PR DESCRIPTION
Python in a virtualenv needs a shared library of that version installed on the system:
```term
(venv) centos@vgcnbwc-worker-c125m425-alma-3127:~$ python --version                                                                                         
python: error while loading shared libraries: libpython3.8.so.1.0: cannot open shared object file: No such file or directory
```