### PR TITLE
Add template for Rocky 9-latest

### DIFF
--- a/templates/build.pkr.hcl
+++ b/templates/build.pkr.hcl
@@ -87,6 +87,22 @@ build {
     shutdown_command = "systemctl poweroff"
   }
 
+  source "source.qemu.base" {
+    name = "rockylinux-9-latest-x86_64"
+    vm_name = "rockylinux-9-latest-x86_64"
+    iso_url = "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9-latest-x86_64-boot.iso"
+    iso_checksum = "sha256:eb096f0518e310f722d5ebd4c69f0322df4fc152c6189f93c5c797dc25f3d2e1"
+    disk_size = "10G"
+    boot_command = [
+      "<esc><wait>",
+      "linux inst.mbr biosdevname=0 net.ifnames=0 ",
+      "rootpw=${var.ssh_password} ",
+      "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/rockylinux-9-latest-x86_64-anaconda-ks.cfg",
+      "<enter>"
+    ]
+    shutdown_command = "systemctl poweroff"
+  }
+
   provisioner "ansible" {
     playbook_file    = "ansible/all-playbooks.yml"
     user             = "root"

--- a/templates/rockylinux-9-latest-x86_64-anaconda-ks.cfg
+++ b/templates/rockylinux-9-latest-x86_64-anaconda-ks.cfg
@@ -1,0 +1,59 @@
+text
+reboot
+url --url=https://ftp.fau.de/rockylinux/9/BaseOS/x86_64/os/
+lang en_US.UTF-8
+keyboard --vckeymap=us --xlayouts='us'
+timezone Europe/Berlin --isUtc --nontp
+clearpart --none --initlabel
+bootloader --location=mbr --boot-drive=vda
+#part biosboot --fstype="biosboot" --ondisk=vda --size=1
+# Clear the Master Boot Record
+firstboot --disable
+zerombr
+# # Remove partitions
+clearpart --all --initlabel
+part / --fstype="xfs" --ondisk=vda --grow --label=system
+
+%packages
+@core
+@^minimal install
+kexec-tools
+%end
+
+# small python script to extract the password from the kernel command line
+# expects the password given as: rootpw=<password>
+%pre --interpreter=/usr/libexec/platform-python
+import shlex, crypt
+arg = 'rootpw='
+with open('/proc/cmdline', 'r') as f:
+  kcl = f.read().split()
+# extract the password
+passwords = [x[len(arg):] for x in kcl if x.startswith(arg)]
+if len(passwords) == 1:
+  kclpass = passwords[0]
+# TODO sane fallbacks. This should work most of the time though :)
+# generate SHA512 hash
+hash = crypt.crypt(kclpass, crypt.mksalt(crypt.METHOD_SHA512))
+with open('/tmp/setup-root-pass', 'w') as f:
+  f.write('rootpw --allow-ssh --iscrypted ' + hash)
+%end
+# include the created password file
+%include /tmp/setup-root-pass
+
+%post --erroronfail
+yum -y update
+yum -y install wget
+yum -y install epel-release
+yum -y install ansible
+# allow root login for ansible
+#sed 's,^[[:blank:]]*#*PermitRootLogin.*,PermitRootLogin yes,g' /etc/ssh/sshd_config
+
+ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 <<EOF
+
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+EOF
+%end


### PR DESCRIPTION
I think this is more handy, because they are removing old minor versions, (like it happened with 9.2 now). The "Rocky-9-latest" option is made for our use case, at least this is how I understand their [readme](https://download.rockylinux.org/pub/rocky/9/isos/x86_64/README). We update the OS minor version anyway, so the output will not the minor version we specify in the template.
This will hopefully prevent breaking builds in the feature.