### PR TITLE
add quiet flag

### DIFF
--- a/build.py
+++ b/build.py
@@ -34,8 +34,6 @@ SSH_HOST = "sn06.galaxyproject.eu"
 
 SSH_USER = "root"
 
-quiet = False
-
 
 def make_parser() -> argparse.ArgumentParser:
     my_parser = argparse.ArgumentParser(

--- a/build.py
+++ b/build.py
@@ -15,6 +15,7 @@
 
 
 import argparse
+import contextlib
 import datetime
 import os
 import pathlib
@@ -32,6 +33,8 @@ STATIC_DIR = pathlib.Path("/data/dnb01/vgcn/").absolute()
 SSH_HOST = "sn06.galaxyproject.eu"
 
 SSH_USER = "root"
+
+quiet = False
 
 
 def make_parser() -> argparse.ArgumentParser:
@@ -85,6 +88,13 @@ def make_parser() -> argparse.ArgumentParser:
     my_parser.add_argument(
         "--comment", type=str, help="add a comment to the image name"
     )
+    my_parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Don't use the spinner, but still print logs.",
+    )
+
     return my_parser
 
 
@@ -129,12 +139,13 @@ class Spinner:
             return False
 
 
-def run_subprocess_with_spinner(name: str, proc: subprocess.Popen):
+def run_subprocess_with_spinner(name: str, proc: subprocess.Popen, show_spinner: bool):
     """
     Opens a subprocess and redirect stdout and stderr to Python.
     Shows a spinning Cursor while the command runs.
     Exits with returncode of subprocess if not equals 0.
     """
+
     try:
         p = None
         # Register handler to pass keyboard interrupt to the subprocess
@@ -147,7 +158,8 @@ def run_subprocess_with_spinner(name: str, proc: subprocess.Popen):
                 raise KeyboardInterrupt.add_note()
 
         signal.signal(signal.SIGINT, handler)
-        with Spinner():
+        context_mgr = Spinner() if show_spinner else contextlib.suppress()
+        with context_mgr:
             print(f"{name.rstrip('Ee')}ing...")
             with proc as p:
                 for line in iter(p.stdout.readline, b""):
@@ -180,6 +192,7 @@ class Build:
         comment: str,
         pvt_key: pathlib.Path,
         ansible_args: str,
+        show_spinner: bool,
     ):
         self.openstack = openstack
         self.template = template
@@ -189,6 +202,7 @@ class Build:
         self.ansible_args = ansible_args
         self.image_name = self.assemble_name()
         self.image_path = DIR_PATH / f"{self.image_name}.raw"
+        self.show_spinner = show_spinner
         if conda_env:
             self.qemu_path = f"{conda_env}/bin/qemu-img"
             self.openstack_path = f"{conda_env}/bin/openstack"
@@ -343,6 +357,7 @@ class Build:
                 close_fds=True,
                 shell=True,
             ),
+            show_spinner=self.show_spinner,
         )
         run_subprocess_with_spinner(
             "BUILD",
@@ -354,6 +369,7 @@ class Build:
                 close_fds=True,
                 shell=True,
             ),
+            show_spinner=self.show_spinner,
         )
 
     def convert(self):
@@ -366,6 +382,7 @@ class Build:
                 close_fds=True,
                 shell=True,
             ),
+            show_spinner=self.show_spinner,
         )
 
     def clean_image_dir(self):
@@ -392,6 +409,7 @@ class Build:
                 close_fds=True,
                 shell=True,
             ),
+            show_spinner=self.show_spinner,
         )
 
     def publish(self):
@@ -404,6 +422,7 @@ class Build:
                 close_fds=True,
                 shell=True,
             ),
+            show_spinner=self.show_spinner,
         )
         run_subprocess_with_spinner(
             "PERMISSION CHANGE",
@@ -414,6 +433,7 @@ class Build:
                 close_fds=True,
                 shell=True,
             ),
+            show_spinner=self.show_spinner,
         )
 
 
@@ -428,6 +448,7 @@ def main():
         comment=args.comment,
         ansible_args=args.ansible_args,
         pvt_key=args.publish,
+        show_spinner=not args.quiet,
     )
     if args.dry_run:
         image.dry_run()


### PR DESCRIPTION
For some reason Jenkins collects all spinners and prints them in a non UTF-8 way instead of just showing them on the side:
~~~
|/-\|/-\|/-\|/-\|/-\==> qemu.rockylinux-9-latest-x86_64: Waiting 10s for boot...
10:48:56 
|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\==> qemu.rockylinux-9-latest-x86_64: Connecting to VM via VNC (127.0.0.1:5903)
10:49:06 
==> qemu.rockylinux-9-latest-x86_64: Typing the boot commands over VNC...
10:49:06 
|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\|/-\    qemu.rockylinux-9-latest-x86_64: Not using a NetBridge -- skipping StepWaitGuestAddress
~~~

With the `-q` flag (name not ideal, because it still prints logs, but I did not came up with something better) the spinner can be disabled