### PR TITLE
Pin docker to 25 because image v1 not supported in 26

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -67,6 +67,12 @@ dynmotd_custom:
     command: "echo  {{ ansible_date_time.iso8601 }}"
 
 # Docker
+docker_packages:
+  - "docker-{{ docker_edition }}-25"
+  - "docker-{{ docker_edition }}-cli-25"
+  - "docker-{{ docker_edition }}-rootless-extras-25"
+  - "containerd.io"
+  - docker-buildx-plugin
 docker_users:
   - centos
   - condor


### PR DESCRIPTION
related to
- https://github.com/usegalaxy-eu/issues/issues/526

Version pinning described here:
https://github.com/geerlingguy/ansible-role-docker?tab=readme-ov-file#role-variables