### PR TITLE
Separate playbooks fix vault

### DIFF
--- a/ansible/playbooks-external.yml
+++ b/ansible/playbooks-external.yml
@@ -1,4 +1,5 @@
-# Meta-playbook that just imports all other playbooks.
+# Meta-playbook for external builds that just imports all other playbooks.
+# Packer selects this playbook if 'internal' is not in the group names.
 #
 # It defines the order in which playbooks should be run during the provisioning
 # step. Each playbook contains plays that only apply to hosts belonging to a
@@ -14,7 +15,5 @@
 - ansible.builtin.import_playbook: workers-gpu.yml
 
 - ansible.builtin.import_playbook: jenkins.yml
-
-- ansible.builtin.import_playbook: internal.yml
 
 - ansible.builtin.import_playbook: external.yml

--- a/ansible/playbooks-internal.yml
+++ b/ansible/playbooks-internal.yml
@@ -1,0 +1,20 @@
+# Meta-playbook for internal images that just imports all other playbooks.
+# This Meta-playbook is selected when packer finds 'internal' in the group names.
+# Requires a --vault-password-file=.vault_password argument in packer.
+#
+# It defines the order in which playbooks should be run during the provisioning
+# step. Each playbook contains plays that only apply to hosts belonging to a
+# group with the same name. Therefore, individual playbooks can be turned on
+# and off via the "groups" variable defined in "templates/variables.pkr.hcl",
+# which can also be overriden form the command line each time packer is
+# launched.
+---
+- ansible.builtin.import_playbook: generic.yml
+
+- ansible.builtin.import_playbook: workers.yml
+
+- ansible.builtin.import_playbook: workers-gpu.yml
+
+- ansible.builtin.import_playbook: jenkins.yml
+
+- ansible.builtin.import_playbook: internal.yml

--- a/templates/build.pkr.hcl
+++ b/templates/build.pkr.hcl
@@ -95,7 +95,7 @@ build {
     name = "rockylinux-9-latest-x86_64"
     vm_name = "rockylinux-9-latest-x86_64"
     iso_url = "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9-latest-x86_64-boot.iso"
-    iso_checksum = "sha256:eb096f0518e310f722d5ebd4c69f0322df4fc152c6189f93c5c797dc25f3d2e1"
+    iso_checksum = "sha256:c7e95e3dba88a1f68fff8b7d4e66adf6f76ac4fba2e246a83c46ab79574c78a8"
     disk_size = "${local.disk_size}"
     boot_command = [
       "<esc><wait>",

--- a/templates/build.pkr.hcl
+++ b/templates/build.pkr.hcl
@@ -108,7 +108,7 @@ build {
   }
 
   provisioner "ansible" {
-    playbook_file    = "${local.playbook}"
+    playbook_file    = "ansible/${local.playbook}"
     user             = "root"
     galaxy_file      = "requirements.yml"
     roles_path       = "ansible/roles/"

--- a/templates/build.pkr.hcl
+++ b/templates/build.pkr.hcl
@@ -108,7 +108,7 @@ build {
   }
 
   provisioner "ansible" {
-    playbook_file    = "ansible/all-playbooks.yml"
+    playbook_file    = "${local.playbook}"
     user             = "root"
     galaxy_file      = "requirements.yml"
     roles_path       = "ansible/roles/"

--- a/templates/variables.pkr.hcl
+++ b/templates/variables.pkr.hcl
@@ -27,6 +27,9 @@ variable "headless" {
   default = "true"
 }
 locals {
+  playbook = contains(var.groups, "internal") ? "playbooks-internal.yml" : "playbooks-external.yml"
+}
+locals {
   vault_password = contains(var.groups, "internal") ? "--vault-password-file=${var.vault_password_file}" : null
 }
 variable "vault_password_file" {


### PR DESCRIPTION
This fixes the packer error
~~~
==> qemu.rockylinux-9-latest-x86_64: Executing Ansible: ansible-playbook -e packer_build_name="base" -e 
packer_builder_type=qemu -e packer_http_addr=10.0.2.2:8164 --ssh-extra-args '-o IdentitiesOnly=yes' -e 
ansible_ssh_private_key_file=/tmp/ansible-key3042192180 -i /tmp/packer-provisioner-ansible2060855767 
/scratch/workspace/usegalaxy-eu/vgcn-workers-external/ansible/all-playbooks.yml
~~~
The meta playbook name is a variable in Packer which is set depending if 'internal' is present in the group name or not.
This way ansible does not try to import the `internal.yml` playbook and by that fails if it is unable to decrypt it's encrypted vars file.