### PR TITLE
Fix/docker prune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ virtualbox-iso/
 vmware-iso/
 packer_plugins/
 ansible/collections
+ansible/roles
 # Created by https://www.gitignore.io/api/packer
 
 ### Packer ###

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -113,7 +113,7 @@ ansible_root_cron:
     weekday: "{{ 7 | random }}"
     minute: "{{ 60 | random }}"
     hour: "{{ 5 | random }}"
-    job: "docker system prune -f"
+    job: "docker system prune -a -f && docker image prune -a -f"
   - name: "Stop containers running more than 1 months"
     weekday: "{{ 7 | random }}"
     minute: "{{ 60 | random }}"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -113,7 +113,7 @@ ansible_root_cron:
     weekday: "{{ 7 | random }}"
     minute: "{{ 60 | random }}"
     hour: "{{ 5 | random }}"
-    job: "docker system prune -a -f && docker image prune -a -f"
+    job: "docker system prune -a -f"
   - name: "Stop containers running more than 1 months"
     weekday: "{{ 7 | random }}"
     minute: "{{ 60 | random }}"


### PR DESCRIPTION
`docker system prune` doenst remove dangling images. 
because of that the worker nodes where with disk full. 