### PR TITLE
Enable Rocky Linux security repository

### DIFF
--- a/ansible/generic.yml
+++ b/ansible/generic.yml
@@ -1,4 +1,35 @@
 ---
+- name: Debug kernel version
+  hosts: generic
+  tasks:
+    - name: Retrieve kernel version
+      ansible.builtin.shell:
+        cmd: uname -r
+      register: kernel
+      changed_when: false
+
+    - name: Print kernel version
+      ansible.builtin.debug:
+        msg: "{{ kernel }}"
+
+- name: Manage package repositories and system updates
+  hosts: generic
+  roles:
+    - role: usegalaxy_eu.rocky_security_repository
+      vars:
+        rocky_security_repository_repo_definitions_upgrade: true
+      become: true
+    - geerlingguy.repo-epel # Install EPEL
+    - usegalaxy-eu.autoupdates # keep all of our packages up to date REMOVED until latest kernel is supported in dnbd3
+  tasks:
+    - name: system update (without kernel update)
+      ansible.builtin.dnf:
+        name: "*"
+        exclude:
+          - kernel*
+          - kmod-kvdo
+        state: latest
+
 - hosts: generic
   vars:
     software_groups_to_install:
@@ -17,20 +48,6 @@
         name: galaxy
         uid: 999
         group: galaxy
-    - name: Debug Kernel version
-      ansible.builtin.shell:
-        cmd: uname -r
-      register: kernel
-    - name: Print kernel version
-      ansible.builtin.debug:
-        msg: "{{ kernel }}"
-    - name: system update (without kernel update)
-      ansible.builtin.dnf:
-        name: "*"
-        exclude:
-          - kernel*
-          - kmod-kvdo
-        state: latest
     - name: Put SELinux in permissive mode, logging actions that would be blocked.
       ansible.posix.selinux:
         policy: targeted
@@ -56,8 +73,6 @@
         enable_grub: true
         enable_kernel_5: "{{ true if (ansible_facts['distribution_major_version'] < '9') else false }}"
 
-    - geerlingguy.repo-epel # Install EPEL
-    - usegalaxy-eu.autoupdates # keep all of our packages up to date REMOVED until latest kernel is supported in dnbd3
     #- usegalaxy-eu.ffmpeg # Uncommnet this to fix https://github.com/usegalaxy-eu/issues/issues/550 
     - usegalaxy-eu.dynmotd
     - influxdata.chrony

--- a/ansible/generic.yml
+++ b/ansible/generic.yml
@@ -31,6 +31,7 @@
         state: latest
 
 - hosts: generic
+  name: Create users and install packages 
   vars:
     software_groups_to_install:
       - admin

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,6 +13,8 @@ collections:
     version: 10.5.2
     source: https://galaxy.ansible.com
     type: galaxy
+  - name: community.general
+    version: 8.2.0
 roles:
   - name: usegalaxy_eu.cuda
     version: 2.0.0
@@ -55,3 +57,6 @@ roles:
     version: 0.1.1
   - name: usegalaxy_eu.ssh_manager
     version: 0.0.2
+  - name: usegalaxy_eu.rocky_security_repository
+    version: v0.1.0
+    src: https://github.com/usegalaxy-eu/ansible-rocky-security-repository


### PR DESCRIPTION
Use the new role `usegalaxy_eu.rocky_security_repository` to enable the repository.

GLM-5.2 summary (that looks good enough to me):

> Rocky Linux has introduced an optional, opt-in Security Repository to ship urgent security fixes ahead of upstream Enterprise Linux when serious vulnerabilities (like CopyFail and Dirty Frag) become publicly exploitable before coordinated fixes arrive. Disabled by default to preserve Rocky's traditional upstream-aligned stability, the repository provides only temporary "bridge" patches that are explicitly versioned to be automatically superseded once upstream releases their own fixes—meaning they carry no errata records and don't appear in `dnf update --security`. The project acknowledges the trade-off: if upstream ultimately declines to fix an issue, the patched package will eventually be replaced by the next upstream release, leaving administrators with options like version-locking rather than an indefinitely maintained fork.

Read the official announcement https://rockylinux.org/news/2026-05-14-introducing-security-repository. Closes https://github.com/usegalaxy-eu/issues/issues/988.

Includes a split of the generic.yml playbook into several plays.